### PR TITLE
🧹 Remove `vite-tsconfig-paths` from `vitest.config.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "tailwindcss": "^4.2.1",
     "tw-animate-css": "^1.3.4",
     "vaul": "^1.1.2",
-    "vite-tsconfig-paths": "^6.0.2",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
-import tsconfigPaths from "vite-tsconfig-paths";
+import path from "path";
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
🎯 What
Removes `vite-tsconfig-paths` from `vitest.config.ts` and replaces it with a manual path alias to `src`.

💡 Why
To resolve a Vite warning about duplicate plugins being registered in Vitest.

✅ Verification
Ran `pnpm test` successfully with the manual path resolution correctly importing modules from `@/...`.

✨ Result
Tests run smoothly without duplicate plugin warnings.

---
*PR created automatically by Jules for task [11938921793041621100](https://jules.google.com/task/11938921793041621100) started by @omordach*