### PR TITLE
🎨 Palette: Add global focus-visible styles for keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-24 - Added Global Focus Visible Outline
+**Learning:** Adding a global focus-visible outline (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background`) for `a` and `button` elements in a `@layer base` block provides excellent default keyboard accessibility. It ensures all interactive elements are clearly outlined when navigating via keyboard, improving WCAG compliance with minimal effort.
+**Action:** Next time I start a new Tailwind project, I'll add this specific snippet to the base layer to immediately secure baseline keyboard accessibility for all standard interactive elements.

--- a/src/styles.css
+++ b/src/styles.css
@@ -109,6 +109,9 @@
     background-color: color-mix(in oklab, var(--accent) 35%, transparent);
     color: var(--foreground);
   }
+  a, button {
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+  }
 }
 
 @utility container-page {


### PR DESCRIPTION
💡 What: Added global focus-visible outline styles (`focus-visible:ring-2`) for all `a` and `button` elements in `src/styles.css`.
🎯 Why: To ensure robust baseline keyboard accessibility by providing clear visual indicators when users navigate via keyboard.
📸 Before/After: Visual outline is now clearly visible on links/buttons when focused.
♿ Accessibility: Improves WCAG compliance for focus indicators across the application without manual class additions.

---
*PR created automatically by Jules for task [2558770665903068089](https://jules.google.com/task/2558770665903068089) started by @omordach*