### PR TITLE
chore: remove availability eyebrow from hero section

### DIFF
--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -2,7 +2,6 @@ export function Hero() {
   return (
     <section id="top" className="relative overflow-hidden">
       <div className="container-page pt-20 pb-28 md:pt-32 md:pb-40">
-        <div className="eyebrow animate-fade">Warsaw, Poland · Available 2026</div>
         <h1 className="display-1 mt-6 max-w-5xl animate-rise">
           Building predictable delivery
           <br />


### PR DESCRIPTION
- Removed the "Warsaw, Poland · Available 2026" eyebrow text from the Hero section as requested.

---
*PR created automatically by Jules for task [17110744728426290973](https://jules.google.com/task/17110744728426290973) started by @omordach*