### PR TITLE
⚡ Bolt: Memoize ChartTooltipContent payload mapping

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-11-20 - Memoizing High-Frequency JSX Loops
+**Learning:** In reusable UI components like custom charts, complex render operations over data arrays (e.g., mapping a tooltip payload) can cause significant performance overhead if executed on every render cycle—especially when triggered by high-frequency events like hover or mouse move.
+**Action:** When working on components that map over data, always consider whether the result can be cached. Wrap expensive `Array.prototype.map` and `.filter` combinations returning JSX inside `React.useMemo` if their inputs are largely stable or only change predictably.

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -149,11 +149,90 @@ const ChartTooltipContent = React.forwardRef<
       return <div className={cn("font-medium", labelClassName)}>{value}</div>;
     }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
 
+    const nestLabel = payload?.length === 1 && indicator !== "dot";
+
+    const tooltipItems = React.useMemo(() => {
+      return payload
+        ?.filter((item) => item.type !== "none")
+        .map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const indicatorColor = color || item.payload.fill || item.color;
+
+          return (
+            <div
+              key={item.dataKey}
+              className={cn(
+                "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                indicator === "dot" && "items-center",
+              )}
+            >
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(item.value, item.name, item, index, item.payload)
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn(
+                          "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                          {
+                            "h-2.5 w-2.5": indicator === "dot",
+                            "w-1": indicator === "line",
+                            "w-0 border-[1.5px] border-dashed bg-transparent":
+                              indicator === "dashed",
+                            "my-0.5": nestLabel && indicator === "dashed",
+                          },
+                        )}
+                        style={
+                          {
+                            "--color-bg": indicatorColor,
+                            "--color-border": indicatorColor,
+                          } as React.CSSProperties
+                        }
+                      />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-1 justify-between leading-none",
+                      nestLabel ? "items-end" : "items-center",
+                    )}
+                  >
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">
+                        {itemConfig?.label || item.name}
+                      </span>
+                    </div>
+                    {item.value && (
+                      <span className="font-mono font-medium tabular-nums text-foreground">
+                        {item.value.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        });
+    }, [
+      payload,
+      config,
+      nameKey,
+      color,
+      indicator,
+      formatter,
+      hideIndicator,
+      nestLabel,
+      tooltipLabel,
+    ]);
+
     if (!active || !payload?.length) {
       return null;
     }
-
-    const nestLabel = payload.length === 1 && indicator !== "dot";
 
     return (
       <div
@@ -164,74 +243,7 @@ const ChartTooltipContent = React.forwardRef<
         )}
       >
         {!nestLabel ? tooltipLabel : null}
-        <div className="grid gap-1.5">
-          {payload
-            .filter((item) => item.type !== "none")
-            .map((item, index) => {
-              const key = `${nameKey || item.name || item.dataKey || "value"}`;
-              const itemConfig = getPayloadConfigFromPayload(config, item, key);
-              const indicatorColor = color || item.payload.fill || item.color;
-
-              return (
-                <div
-                  key={item.dataKey}
-                  className={cn(
-                    "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-                    indicator === "dot" && "items-center",
-                  )}
-                >
-                  {formatter && item?.value !== undefined && item.name ? (
-                    formatter(item.value, item.name, item, index, item.payload)
-                  ) : (
-                    <>
-                      {itemConfig?.icon ? (
-                        <itemConfig.icon />
-                      ) : (
-                        !hideIndicator && (
-                          <div
-                            className={cn(
-                              "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
-                              {
-                                "h-2.5 w-2.5": indicator === "dot",
-                                "w-1": indicator === "line",
-                                "w-0 border-[1.5px] border-dashed bg-transparent":
-                                  indicator === "dashed",
-                                "my-0.5": nestLabel && indicator === "dashed",
-                              },
-                            )}
-                            style={
-                              {
-                                "--color-bg": indicatorColor,
-                                "--color-border": indicatorColor,
-                              } as React.CSSProperties
-                            }
-                          />
-                        )
-                      )}
-                      <div
-                        className={cn(
-                          "flex flex-1 justify-between leading-none",
-                          nestLabel ? "items-end" : "items-center",
-                        )}
-                      >
-                        <div className="grid gap-1.5">
-                          {nestLabel ? tooltipLabel : null}
-                          <span className="text-muted-foreground">
-                            {itemConfig?.label || item.name}
-                          </span>
-                        </div>
-                        {item.value && (
-                          <span className="font-mono font-medium tabular-nums text-foreground">
-                            {item.value.toLocaleString()}
-                          </span>
-                        )}
-                      </div>
-                    </>
-                  )}
-                </div>
-              );
-            })}
-        </div>
+        <div className="grid gap-1.5">{tooltipItems}</div>
       </div>
     );
   },


### PR DESCRIPTION
💡 **What:** Wrapped the JSX list rendering logic of `payload` (a `filter` followed by `map`) inside `ChartTooltipContent` within a `React.useMemo` hook.

🎯 **Why:** The `ChartTooltipContent` component is repeatedly re-rendered as the user interacts with the chart (e.g., hovering across data points). Executing `filter` and `map` on the payload repeatedly incurs unnecessary CPU overhead when the inputs have not changed. Memoizing the results prevents this expensive work.

📊 **Measured Improvement:** We verified the application builds successfully and that the rendering functions correctly. Due to the difficulty of creating an isolated static benchmark that replicates rapid re-render events tied to pointer movements, we could not provide a statistically significant numerical improvement from `renderToString`. However, memoizing expensive O(n) array operations during rapid interaction sequences is a well-established performance pattern that structurally eliminates dispatcher overhead for these components.

---
*PR created automatically by Jules for task [14214454574053270781](https://jules.google.com/task/14214454574053270781) started by @omordach*