### PR TITLE
🛡️ Sentinel: [security improvement] Add noopener to external link

### DIFF
--- a/src/components/sections/contact.tsx
+++ b/src/components/sections/contact.tsx
@@ -10,7 +10,7 @@ export function Contact() {
           <a
             href="https://www.linkedin.com/in/oleh-mordach/"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="bg-background px-6 py-8 group"
           >
             <div className="eyebrow">LinkedIn</div>


### PR DESCRIPTION
🚨 Severity: Low
💡 Vulnerability: Reverse tabnabbing. Without `noopener`, the newly opened tab gains access to the `window.opener` object of the original page, which could potentially be abused to navigate the original page to a malicious URL.
🎯 Impact: Minimal, but good hygiene
🛠️ Fix: Adding `noopener` explicitly drops the `window.opener` reference in the newly opened tab, preventing reverse tabnabbing attacks while retaining `noreferrer` for privacy.
✅ Verification: Ran tests, lint, and playwright verification.

---
*PR created automatically by Jules for task [1338274915345274482](https://jules.google.com/task/1338274915345274482) started by @omordach*