### PR TITLE
🔒 Sentinel: [HIGH] Fix sensitive info exposure in SSR logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-08 - SSR Error Response Body Redaction
+**Vulnerability:** A generic SSR error payload from h3 (`{"unhandled":true,"message":"HTTPError"}`) or unhandled catastrophic errors was being directly included in the server log via `console.error` in `src/server.ts`, potentially leaking sensitive information present in the raw body of a failed request.
+**Learning:** Raw response bodies, especially from generic SSR or unhandled exception handlers, should never be blindly logged, as they might contain unredacted sensitive payload fragments from internal components that failed to process correctly.
+**Prevention:** Always parse and explicitly extract only the known safe fields (like `message` or predefined error codes) from a raw error body before passing it to logging systems; if parsing fails, fallback to a standard `[redacted]` string.

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,20 @@ async function normalizeCatastrophicSsrResponse(response: Response): Promise<Res
     return response;
   }
 
-  console.error(consumeLastCapturedError() ?? new Error(`h3 swallowed SSR error: ${body}`));
+  let sanitizedBody = "[redacted]";
+  try {
+    const parsed = JSON.parse(body);
+    sanitizedBody = JSON.stringify({
+      unhandled: parsed.unhandled,
+      message: parsed.message,
+    });
+  } catch (e) {
+    // Fallback to [redacted]
+  }
+
+  console.error(
+    consumeLastCapturedError() ?? new Error(`h3 swallowed SSR error: ${sanitizedBody}`),
+  );
   return new Response(renderErrorPage(), {
     status: 500,
     headers: { "content-type": "text/html; charset=utf-8" },


### PR DESCRIPTION
🎯 **What:** Sanitized the generic SSR error body to only extract and log known safe properties (`message`, `unhandled`) before passing it to `console.error`, falling back to a `"[redacted]"` string if parsing fails.

⚠️ **Risk:** Blindly logging the full, unparsed error body from the request response could expose sensitive internal data, tokens, or PII that failed to process.

🛡️ **Solution:** Replaced the direct string interpolation of the response text with a try/catch block that attempts to JSON parse it and creates a safe JSON string containing only the necessary properties.

---
*PR created automatically by Jules for task [13328899084810029074](https://jules.google.com/task/13328899084810029074) started by @omordach*