### PR TITLE
🧹 Remove unused empty type import in sitemap route

### DIFF
--- a/src/routes/sitemap[.]xml.ts
+++ b/src/routes/sitemap[.]xml.ts
@@ -1,5 +1,4 @@
 import { createFileRoute } from "@tanstack/react-router";
-import type {} from "@tanstack/react-start";
 
 const BASE_URL = "https://mordach.com";
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `import type {} from "@tanstack/react-start";` from `src/routes/sitemap[.]xml.ts`.
💡 **Why:** The import was completely empty and served no purpose. Removing dead code improves readability and maintainability.
✅ **Verification:** Ran `pnpm lint` and `pnpm test` to confirm no functionality was broken.
✨ **Result:** Cleaner code in the sitemap route file without any unnecessary imports.

---
*PR created automatically by Jules for task [3734091777336792257](https://jules.google.com/task/3734091777336792257) started by @omordach*